### PR TITLE
Actualizado el enlace a Meetup de Rioja{dotnet}

### DIFF
--- a/content/post/vigotech-grupos.html
+++ b/content/post/vigotech-grupos.html
@@ -52,7 +52,7 @@ class="post first groups"
 				<a href="https://twitter.com/RiojaDotNet">
 					<i class="fa fa-twitter"></i>
 				</a>
-				<a href="https://www.meetup.com/es-ES/GDG-La-Rioja/">
+				<a href="https://www.meetup.com/es-ES/RiojaDotNet/">
 					<i class="fa fa-meetup"></i>
 				</a>
 				<a href="https://github.com/RiojaDotNet/">


### PR DESCRIPTION
Actualizado el enlace a Meetup de Rioja{dotnet} (https://www.meetup.com/es-ES/RiojaDotNet/)